### PR TITLE
Use locale instead of sppLocale in get_taxonomy

### DIFF
--- a/src/ebird/api/taxonomy.py
+++ b/src/ebird/api/taxonomy.py
@@ -51,7 +51,7 @@ def get_taxonomy(token, category=None, locale="en", version=None, species=None):
     :raises HTTPError if the eBird API returns an error.
 
     """
-    params = {"sppLocale": clean_locale(locale), "fmt": "json"}
+    params = {"locale": clean_locale(locale), "fmt": "json"}
 
     if category is not None:
         params["cat"] = ",".join(clean_categories(category))


### PR DESCRIPTION
I found out that while trying to get taxonomy in other languages such as fr, the variable sppLocale is not working.  replacing it with locale works as it should.