### PR TITLE
Add rank parameter to get_historic_observations

### DIFF
--- a/src/ebird/api/client.py
+++ b/src/ebird/api/client.py
@@ -41,6 +41,7 @@ class Client:
         self.hotspot = False
         self.provisional = True
         self.sort = "date"
+        self.rank = "mrec"
 
     def get_observations(self, area):
         """Get recent observations (up to 30 days ago) for a region or location.
@@ -127,6 +128,7 @@ class Client:
             hotspot=self.hotspot,
             detail=self.detail,
             category=self.category,
+            rank=self.rank,
         )
 
     def get_nearby_observations(self, lat, lng, dist=25):

--- a/src/ebird/api/observations.py
+++ b/src/ebird/api/observations.py
@@ -15,6 +15,7 @@ from ebird.api.validation import (
     clean_locale,
     clean_max_observations,
     clean_provisional,
+    clean_observation_rank,
     clean_sort,
 )
 
@@ -633,6 +634,7 @@ def get_historic_observations(
     hotspot=False,
     detail="simple",
     category=None,
+    rank="mrec",
 ):
     """Get recent observations for a region.
 
@@ -671,6 +673,10 @@ def get_historic_observations(
     More than one value can be given in a comma-separated string. The default
     value is None and records from all categories will be returned.
 
+    :param rank: return the last (rank='mrec') or first(rank='create')
+    observation on the date. See the eBird API documentation for a description
+    of the fields.
+
     :return: the list of observations in simple format.
 
     :raises ValueError: if any of the arguments fail the validation checks.
@@ -686,7 +692,7 @@ def get_historic_observations(
     url = HISTORIC_OBSERVATIONS_URL % (cleaned[0], date.strftime("%Y/%m/%d"))
 
     params = {
-        "rank": "mrec",
+        "rank": clean_observation_rank(rank),
         "detail": clean_detail(detail),
         "sppLocale": clean_locale(locale),
         "includeProvisional": clean_provisional(provisional),

--- a/src/ebird/api/validation.py
+++ b/src/ebird/api/validation.py
@@ -200,6 +200,15 @@ def clean_detail(value):
     return cleaned
 
 
+def clean_observation_rank(value):
+    cleaned = clean_code(value, transform=Transform.LOWER)
+    if cleaned not in ("mrec", "create"):
+        raise ValueError(
+            "Value for 'rank', %s, must be either 'mrec' or 'create'" % value
+        )
+    return cleaned
+
+
 def clean_provisional(value):
     return "true" if bool(value) else "false"
 

--- a/tests/unit/validation/test_clean_observation_rank.py
+++ b/tests/unit/validation/test_clean_observation_rank.py
@@ -1,0 +1,13 @@
+import unittest
+
+from ebird.api.validation import clean_observation_rank
+
+
+class CleanObservationRankTests(unittest.TestCase):
+    """Tests for the rank validation function."""
+
+    def test_codes_are_lower_case(self):
+        self.assertEqual("mrec", clean_observation_rank("Mrec"))
+
+    def test_invalid_code_raises_error(self):
+        self.assertRaises(ValueError, clean_observation_rank, "none")


### PR DESCRIPTION
This PR addresses #25 which I created. I needed to get the first observation of a taxa on the date specified for `get_historic_observations`. This functionality is provided in the eBird API but was not made available in this python wrapper.

I attempted to follow the coding standards. The changes are simple.

I also tested that the existing functionality still works - either as default, or by passing the parameter it had been defaulting to.

I hope this is useful! I appreciate the work to put this wrapper together and am glad to contribute back.

```python
# demonstrate that existing functionality is still supported when no rank is supplied
# It should print a time when the Clapper Rail was seen at the end of the day
observations = get_historic_observations(
    token=ebird_api_key, area='US-VA-003', date=date(2021, 4, 9), category="species"
)
clapper_rail_obs = next((obs for obs in observations if obs.get('comName') == 'Clapper Rail'), None)
print(clapper_rail_obs.get('obsDt'))

# demonstrate that new functionality is supported when rank=="create
# It should print a time when the Clapper Rail was seen at the beginning of the day
observations = get_historic_observations(
    token=ebird_api_key, area='US-VA-003', date=date(2021, 4, 9), category="species", rank="create"
)
clapper_rail_obs = next(
    (obs for obs in observations if obs.get("comName") == "Clapper Rail"), None
)
print(clapper_rail_obs.get("obsDt"))

# demonstrate that new functionality is supported when rank=="mrec"
# It should print a time when the Clapper Rail was seen at the end of the day
observations = get_historic_observations(
    token=ebird_api_key, area='US-VA-003', date=date(2021, 4, 9), category="species", rank="mrec"
)
clapper_rail_obs = next(
    (obs for obs in observations if obs.get("comName") == "Clapper Rail"), None
)
print(clapper_rail_obs.get("obsDt"))
```
and the results are correct, showing evening, morning, evening.

```text
2021-04-09 19:15
2021-04-09 07:08
2021-04-09 19:15
```